### PR TITLE
fix windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This package extracts unexported code from `golang.org/x/unix` to help in conver
 between:
 
 ```Go
-unix.Sockaddr
-unix.RawSockaddrAny
+${platform}.Sockaddr
+${platform}.RawSockaddrAny
 C.struct_sockaddr_any
 net.*Addr
 ```

--- a/net/net_bsd.go
+++ b/net/net_bsd.go
@@ -22,3 +22,9 @@ const (
 	SOCK_STREAM    = unix.SOCK_STREAM
 	SOCK_SEQPACKET = unix.SOCK_SEQPACKET
 )
+
+type Sockaddr = unix.Sockaddr
+type SockaddrInet4 = unix.SockaddrInet4
+type SockaddrInet6 = unix.SockaddrInet6
+type SockaddrUnix = unix.SockaddrUnix
+type RawSockaddrAny = unix.RawSockaddrAny

--- a/net/net_linux.go
+++ b/net/net_linux.go
@@ -20,3 +20,9 @@ const (
 	SOCK_STREAM    = unix.SOCK_STREAM
 	SOCK_SEQPACKET = unix.SOCK_SEQPACKET
 )
+
+type Sockaddr = unix.Sockaddr
+type SockaddrInet4 = unix.SockaddrInet4
+type SockaddrInet6 = unix.SockaddrInet6
+type SockaddrUnix = unix.SockaddrUnix
+type RawSockaddrAny = unix.RawSockaddrAny

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -11,7 +11,7 @@ const (
 	AF_UNSPEC = windows.AF_UNSPEC
 
 	IPPROTO_IP   = windows.IPPROTO_IP
-	IPPROTO_IPV4 = windows.IPPROTO_IPV4
+	IPPROTO_IPV4 = 0x4 // windows.IPPROTO_IPV4 (missing)
 	IPPROTO_IPV6 = windows.IPPROTO_IPV6
 	IPPROTO_TCP  = windows.IPPROTO_TCP
 	IPPROTO_UDP  = windows.IPPROTO_UDP

--- a/net/net_windows.go
+++ b/net/net_windows.go
@@ -1,22 +1,28 @@
 package sockaddrnet
 
 import (
-	"golang.org/x/sys/unix"
+	"golang.org/x/sys/windows"
 )
 
 const (
-	AF_INET   = unix.AF_INET
-	AF_INET6  = unix.AF_INET6
-	AF_UNIX   = unix.AF_UNIX
-	AF_UNSPEC = unix.AF_UNSPEC
+	AF_INET   = windows.AF_INET
+	AF_INET6  = windows.AF_INET6
+	AF_UNIX   = windows.AF_UNIX
+	AF_UNSPEC = windows.AF_UNSPEC
 
-	IPPROTO_IP   = unix.IPPROTO_IP
-	IPPROTO_IPV4 = unix.IPPROTO_IPV4
-	IPPROTO_IPV6 = unix.IPPROTO_IPV6
-	IPPROTO_TCP  = unix.IPPROTO_TCP
-	IPPROTO_UDP  = unix.IPPROTO_UDP
+	IPPROTO_IP   = windows.IPPROTO_IP
+	IPPROTO_IPV4 = windows.IPPROTO_IPV4
+	IPPROTO_IPV6 = windows.IPPROTO_IPV6
+	IPPROTO_TCP  = windows.IPPROTO_TCP
+	IPPROTO_UDP  = windows.IPPROTO_UDP
 
-	SOCK_DGRAM     = unix.SOCK_DGRAM
-	SOCK_STREAM    = unix.SOCK_STREAM
-	SOCK_SEQPACKET = unix.SOCK_SEQPACKET
+	SOCK_DGRAM     = windows.SOCK_DGRAM
+	SOCK_STREAM    = windows.SOCK_STREAM
+	SOCK_SEQPACKET = windows.SOCK_SEQPACKET
 )
+
+type Sockaddr = windows.Sockaddr
+type SockaddrInet4 = windows.SockaddrInet4
+type SockaddrInet6 = windows.SockaddrInet6
+type SockaddrUnix = windows.SockaddrUnix
+type RawSockaddrAny = windows.RawSockaddrAny

--- a/sockaddr.go
+++ b/sockaddr.go
@@ -1,8 +1,9 @@
 package sockaddr
 
 import (
-	"golang.org/x/sys/unix"
 	"unsafe"
+
+	sockaddrnet "github.com/libp2p/go-sockaddr/net"
 )
 
 import "C"
@@ -10,24 +11,24 @@ import "C"
 // Socklen is a type for the length of a sockaddr.
 type Socklen uint
 
-// SockaddrToAny converts a unix.Sockaddr into a unix.RawSockaddrAny
+// SockaddrToAny converts a Sockaddr into a RawSockaddrAny
 // The implementation is platform dependent.
-func SockaddrToAny(sa unix.Sockaddr) (*unix.RawSockaddrAny, Socklen, error) {
+func SockaddrToAny(sa sockaddrnet.Sockaddr) (*sockaddrnet.RawSockaddrAny, Socklen, error) {
 	return sockaddrToAny(sa)
 }
 
-// SockaddrToAny converts a unix.RawSockaddrAny into a unix.Sockaddr
+// SockaddrToAny converts a RawSockaddrAny into a Sockaddr
 // The implementation is platform dependent.
-func AnyToSockaddr(rsa *unix.RawSockaddrAny) (unix.Sockaddr, error) {
+func AnyToSockaddr(rsa *sockaddrnet.RawSockaddrAny) (sockaddrnet.Sockaddr, error) {
 	return anyToSockaddr(rsa)
 }
 
 // AnyToCAny casts a *RawSockaddrAny to a *C.struct_sockaddr_any
-func AnyToCAny(a *unix.RawSockaddrAny) *C.struct_sockaddr_any {
+func AnyToCAny(a *sockaddrnet.RawSockaddrAny) *C.struct_sockaddr_any {
 	return (*C.struct_sockaddr_any)(unsafe.Pointer(a))
 }
 
 // CAnyToAny casts a *C.struct_sockaddr_any to a *RawSockaddrAny
-func CAnyToAny(a *C.struct_sockaddr_any) *unix.RawSockaddrAny {
-	return (*unix.RawSockaddrAny)(unsafe.Pointer(a))
+func CAnyToAny(a *C.struct_sockaddr_any) *sockaddrnet.RawSockaddrAny {
+	return (*sockaddrnet.RawSockaddrAny)(unsafe.Pointer(a))
 }

--- a/sockaddr_windows.go
+++ b/sockaddr_windows.go
@@ -25,7 +25,7 @@ func sockaddrToAny(sa windows.Sockaddr) (*windows.RawSockaddrAny, Socklen, error
 		for i := 0; i < len(sa.Addr); i++ {
 			raw.Addr[i] = sa.Addr[i]
 		}
-		return (*windows.RawSockaddrAny)(unsafe.Pointer(&raw)), int32(unsafe.Sizeof(raw)), nil
+		return (*windows.RawSockaddrAny)(unsafe.Pointer(&raw)), Socklen(unsafe.Sizeof(raw)), nil
 
 	case *windows.SockaddrInet6:
 		if sa.Port < 0 || sa.Port > 0xFFFF {
@@ -40,7 +40,7 @@ func sockaddrToAny(sa windows.Sockaddr) (*windows.RawSockaddrAny, Socklen, error
 		for i := 0; i < len(sa.Addr); i++ {
 			raw.Addr[i] = sa.Addr[i]
 		}
-		return (*windows.RawSockaddrAny)(unsafe.Pointer(&raw)), int32(unsafe.Sizeof(raw)), nil
+		return (*windows.RawSockaddrAny)(unsafe.Pointer(&raw)), Socklen(unsafe.Sizeof(raw)), nil
 
 	case *windows.SockaddrUnix:
 		return nil, 0, syscall.EWINDOWS
@@ -50,7 +50,7 @@ func sockaddrToAny(sa windows.Sockaddr) (*windows.RawSockaddrAny, Socklen, error
 
 func anyToSockaddr(rsa *windows.RawSockaddrAny) (windows.Sockaddr, error) {
 	if rsa == nil {
-		return nil, 0, syscall.EINVAL
+		return nil, syscall.EINVAL
 	}
 
 	switch rsa.Addr.Family {

--- a/sockaddr_windows.go
+++ b/sockaddr_windows.go
@@ -1,36 +1,38 @@
 package sockaddr
 
 import (
-	"golang.org/x/sys/unix"
+	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
-func sockaddrToAny(sa unix.Sockaddr) (*unix.RawSockaddrAny, Socklen, error) {
+func sockaddrToAny(sa windows.Sockaddr) (*windows.RawSockaddrAny, Socklen, error) {
 	if sa == nil {
-		return nil, 0, unix.EINVAL
+		return nil, 0, syscall.EINVAL
 	}
 
 	switch sa := sa.(type) {
-	case *unix.SockaddrInet4:
+	case *windows.SockaddrInet4:
 		if sa.Port < 0 || sa.Port > 0xFFFF {
-			return nil, 0, unix.EINVAL
+			return nil, 0, syscall.EINVAL
 		}
-		var raw unix.RawSockaddrInet4
-		raw.Family = unix.AF_INET
+		var raw windows.RawSockaddrInet4
+		raw.Family = windows.AF_INET
 		p := (*[2]byte)(unsafe.Pointer(&raw.Port))
 		p[0] = byte(sa.Port >> 8)
 		p[1] = byte(sa.Port)
 		for i := 0; i < len(sa.Addr); i++ {
 			raw.Addr[i] = sa.Addr[i]
 		}
-		return (*unix.RawSockaddrAny)(unsafe.Pointer(&raw)), int32(unsafe.Sizeof(raw)), nil
+		return (*windows.RawSockaddrAny)(unsafe.Pointer(&raw)), int32(unsafe.Sizeof(raw)), nil
 
-	case *unix.SockaddrInet6:
+	case *windows.SockaddrInet6:
 		if sa.Port < 0 || sa.Port > 0xFFFF {
-			return nil, 0, unix.EINVAL
+			return nil, 0, syscall.EINVAL
 		}
-		var raw unix.RawSockaddrInet6
-		raw.Family = unix.AF_INET6
+		var raw windows.RawSockaddrInet6
+		raw.Family = windows.AF_INET6
 		p := (*[2]byte)(unsafe.Pointer(&raw.Port))
 		p[0] = byte(sa.Port >> 8)
 		p[1] = byte(sa.Port)
@@ -38,26 +40,26 @@ func sockaddrToAny(sa unix.Sockaddr) (*unix.RawSockaddrAny, Socklen, error) {
 		for i := 0; i < len(sa.Addr); i++ {
 			raw.Addr[i] = sa.Addr[i]
 		}
-		return (*unix.RawSockaddrAny)(unsafe.Pointer(&raw)), int32(unsafe.Sizeof(raw)), nil
+		return (*windows.RawSockaddrAny)(unsafe.Pointer(&raw)), int32(unsafe.Sizeof(raw)), nil
 
-	case *unix.SockaddrUnix:
-		return nil, 0, unix.EWINDOWS
+	case *windows.SockaddrUnix:
+		return nil, 0, syscall.EWINDOWS
 	}
-	return nil, 0, unix.EAFNOSUPPORT
+	return nil, 0, syscall.EAFNOSUPPORT
 }
 
-func anyToSockaddr(rsa *unix.RawSockaddrAny) (unix.Sockaddr, error) {
+func anyToSockaddr(rsa *windows.RawSockaddrAny) (windows.Sockaddr, error) {
 	if rsa == nil {
-		return nil, 0, unix.EINVAL
+		return nil, 0, syscall.EINVAL
 	}
 
 	switch rsa.Addr.Family {
-	case unix.AF_UNIX:
-		return nil, unix.EWINDOWS
+	case windows.AF_UNIX:
+		return nil, syscall.EWINDOWS
 
-	case unix.AF_INET:
-		pp := (*unix.RawSockaddrInet4)(unsafe.Pointer(rsa))
-		sa := new(unix.SockaddrInet4)
+	case windows.AF_INET:
+		pp := (*windows.RawSockaddrInet4)(unsafe.Pointer(rsa))
+		sa := new(windows.SockaddrInet4)
 		p := (*[2]byte)(unsafe.Pointer(&pp.Port))
 		sa.Port = int(p[0])<<8 + int(p[1])
 		for i := 0; i < len(sa.Addr); i++ {
@@ -65,9 +67,9 @@ func anyToSockaddr(rsa *unix.RawSockaddrAny) (unix.Sockaddr, error) {
 		}
 		return sa, nil
 
-	case unix.AF_INET6:
-		pp := (*unix.RawSockaddrInet6)(unsafe.Pointer(rsa))
-		sa := new(unix.SockaddrInet6)
+	case windows.AF_INET6:
+		pp := (*windows.RawSockaddrInet6)(unsafe.Pointer(rsa))
+		sa := new(windows.SockaddrInet6)
 		p := (*[2]byte)(unsafe.Pointer(&pp.Port))
 		sa.Port = int(p[0])<<8 + int(p[1])
 		sa.ZoneId = pp.Scope_id
@@ -76,5 +78,5 @@ func anyToSockaddr(rsa *unix.RawSockaddrAny) (unix.Sockaddr, error) {
 		}
 		return sa, nil
 	}
-	return nil, unix.EAFNOSUPPORT
+	return nil, syscall.EAFNOSUPPORT
 }


### PR DESCRIPTION
1. Switch back to the syscall package for errors. That way, we get consistent errors on all platforms.
2. Use `sys/windows` where appropriate.
3. Export type aliases for the *Sockaddr* types. That way, we can use the platform-specific types but call them the same name, regardless of platform.