### PR TITLE
set the V4InV6Prefix correctly (like go does)

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -195,6 +195,9 @@ func SockaddrToIPAndZone(sa Sockaddr) (net.IP, string) {
 	switch sa := sa.(type) {
 	case *SockaddrInet4:
 		ip := make([]byte, 16)
+		// V4InV6Prefix
+		ip[10] = 0xff
+		ip[11] = 0xff
 		copy(ip[12:16], sa.Addr[:])
 		return ip, ""
 


### PR DESCRIPTION
This is why go uses 16 byte arrays for all addresses by default.