### PR TITLE
Just repair a commentate mistake.

### DIFF
--- a/net/net.go
+++ b/net/net.go
@@ -196,7 +196,7 @@ func UnixAddrToSockaddr(addr *net.UnixAddr) (Sockaddr, int) {
 	return &SockaddrUnix{Name: addr.Name}, t
 }
 
-// IPAndZoneToSockaddr converts a net.IP (with optional IPv6 Zone) to a Sockaddr
+// SockaddrToIPAndZone converts a Sockaddr to a net.IP (with optional IPv6 Zone)
 // Returns nil if conversion fails.
 func SockaddrToIPAndZone(sa Sockaddr) (net.IP, string) {
 	switch sa := sa.(type) {


### PR DESCRIPTION
The commentate of function SockaddrToIPAndZone is same with
IPAndZoneToSockaddr. Repaired.

Signed-off-by: gukq <gukaiqiang@gmail.com>