### PR TITLE
deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATION NOTICE
+
+This repository is not maintained any longer.
+
 ## go-sockaddr - `{Raw,}Sockaddr` conversions
 
 See https://groups.google.com/d/msg/golang-nuts/B-meiFfkmH0/-TxP1r6zvk8J

--- a/net/net.go
+++ b/net/net.go
@@ -1,4 +1,5 @@
-// package sockaddrnet provides conversions between net.Addr and Sockaddr
+// Package sockaddrnet provides conversions between net.Addr and Sockaddr
+// Deprecated: This package is not maintained any longer.
 package sockaddrnet
 
 import (

--- a/sockaddr.go
+++ b/sockaddr.go
@@ -1,3 +1,4 @@
+// Deprecated: This package is not maintained any longer.
 package sockaddr
 
 import (

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.1"
+  "version": "v0.2.0"
 }


### PR DESCRIPTION
Depends on https://github.com/libp2p/go-netroute/pull/22.